### PR TITLE
fix: call use_context in the use_context_interactive

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -77,6 +77,6 @@ impl ctx::CTX for AWS {
             .ok_or(ctx::CTXError::UnexpectedError {
                 source: anyhow!("unexpected error"),
             })?;
-        return self.use_context(&context.name);
+        self.use_context(&context.name)
     }
 }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -70,12 +70,13 @@ impl ctx::CTX for AWS {
             .ok_or(ctx::CTXError::InvalidArgument {
                 source: anyhow!("no context is selected"),
             })?;
-        (*item)
+        let context = (*item)
             .as_any()
             .downcast_ref::<ctx::Context>()
             .cloned()
             .ok_or(ctx::CTXError::UnexpectedError {
                 source: anyhow!("unexpected error"),
-            })
+            })?;
+        return self.use_context(&context.name);
     }
 }


### PR DESCRIPTION
awsctx is an awesome tool!

I have found a bug, so I fixed it.
The Interactive UI doesn't update profile because `use_context_interactive` doesn't call `use_context`.