### PR TITLE
:sparkles: implement `__default` option to auth commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ config = {version = "0.13.1", features = ["ini", "yaml"]}
 dirs = "4.0.0"
 handlebars = "4.3.3"
 log = "0.4.17"
+maplit = "1.0.2"
 once_cell = "1.13.0"
 regex = "1.6.0"
 rust-ini = "0.18.0"
@@ -28,6 +29,5 @@ skim = "0.9.4"
 thiserror = "1.0.31"
 
 [dev-dependencies]
-maplit = "1.0.2"
 rstest = "0.15.0"
 tempfile = "3.3.0"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ auth_commands:
   bar: |
     # In this case, name of one-login configuration is same as `profile`
     onelogin-aws-login -C {{profile}} --profile {{profile}} -u user@example.com
+  # default configuration for profiles without auth configuration
+  __default: |
+    aws configure --profile {{profile}}
 ```
 
 ### Configure Completion

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashMap,
     io::{Seek, SeekFrom, Write},
     rc::Rc,
 };
 
+use maplit::hashmap;
 use rstest::*;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,12 @@ use awsctx::{configs::Configs, creds::Credentials, ctx};
 
 #[fixture]
 pub fn aws_credentials_text() -> String {
-    r#"[bar]
+    r#"[baz]
+aws_access_key_id=ZZZZZZZZZZZ
+aws_secret_access_key=ZZZZZZZZZZZ
+aws_session_token=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
+[bar]
 aws_access_key_id=YYYYYYYYYYY
 aws_secret_access_key=YYYYYYYYYYY
 aws_session_token=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
@@ -71,6 +76,10 @@ pub fn contexts() -> Vec<ctx::Context> {
             active: false,
         },
         ctx::Context {
+            name: "baz".to_string(),
+            active: false,
+        },
+        ctx::Context {
             name: "foo".to_string(),
             active: true,
         },
@@ -94,11 +103,20 @@ pub fn contexts_without_default() -> Vec<ctx::Context> {
 #[fixture]
 pub fn configs() -> Rc<Configs> {
     Rc::new(Configs {
-        auth_commands: vec![
-            ("foo".to_string(), "echo auth".to_string()),
-            ("bar".to_string(), "exit 1".to_string()),
-        ]
-        .into_iter()
-        .collect::<HashMap<String, String>>(),
+        auth_commands: hashmap! {
+           "foo".to_string() => "echo auth".to_string(),
+              "bar".to_string() => "exit 1".to_string(),
+              Configs::DEFAULT_AUTH_COMMAND_KEY.to_string() => "echo default auth".to_string(),
+        },
+    })
+}
+
+#[fixture]
+pub fn configs_without_default() -> Rc<Configs> {
+    Rc::new(Configs {
+        auth_commands: hashmap! {
+           "foo".to_string() => "echo auth".to_string(),
+              "bar".to_string() => "exit 1".to_string(),
+        },
     })
 }


### PR DESCRIPTION
add `__default` field for default configurations of auth command

closes #51 